### PR TITLE
Create GitHub has an age restriction.md

### DIFF
--- a/GitHub has an age restriction.md
+++ b/GitHub has an age restriction.md
@@ -1,0 +1,13 @@
+Yes, **GitHub has an age restriction**. According to their [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service), users must meet certain age requirements to create an account:
+
+1. **Minimum Age:**  
+   - You must be at least **13 years old** to use GitHub, regardless of your location.
+   - In some jurisdictions, the age limit may be higher due to local laws (e.g., 16 in the European Union under the GDPR).
+
+2. **Parental Consent:**  
+   - If you're below the legal age of majority in your jurisdiction, you may need permission from a parent or legal guardian to use GitHub.
+
+3. **Compliance with Local Laws:**  
+   - The age requirement may vary depending on the laws in your country. GitHub enforces these restrictions based on applicable regulations.
+
+If you're thinking about a situation where younger users might want to use GitHub (like kids for coding classes), a parent or guardian could create and manage an account on their behalf, if compliant with the platform's terms and local laws.


### PR DESCRIPTION
Yes, **GitHub has an age restriction**. According to their [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service), users must meet certain age requirements to create an account:

1. **Minimum Age:**  
   - You must be at least **13 years old** to use GitHub, regardless of your location.
   - In some jurisdictions, the age limit may be higher due to local laws (e.g., 16 in the European Union under the GDPR).

2. **Parental Consent:**  
   - If you're below the legal age of majority in your jurisdiction, you may need permission from a parent or legal guardian to use GitHub.

3. **Compliance with Local Laws:**  
   - The age requirement may vary depending on the laws in your country. GitHub enforces these restrictions based on applicable regulations.

If you're thinking about a situation where younger users might want to use GitHub (like kids for coding classes), a parent or guardian could create and manage an account on their behalf, if compliant with the platform's terms and local laws.