### PR TITLE
Create "Go to hell".md

### DIFF
--- a/"Go to hell".md
+++ b/"Go to hell".md
@@ -1,0 +1,36 @@
+In the United States, the rights of non-native English speakers are protected in specific contexts under federal laws and policies, though challenges and ambiguities persist. Below is a synthesis of key legal and societal considerations:
+
+### 1. **Employment Protections**  
+Under **Title VII of the Civil Rights Act of 1964**, discrimination based on national origin—which includes language and accent—is prohibited. Employers cannot legally require a job applicant to be a "native speaker" unless they can prove that native-level fluency is essential for the role (e.g., editing, translation). Even then, the requirement must be narrowly tailored to actual job needs, not based on stereotypes about non-native speakers. For example, blanket English fluency requirements for roles where it is unnecessary (e.g., warehouse work) may violate anti-discrimination laws . Accent-based discrimination is only permissible if the accent "materially interferes" with job performance .
+
+---
+
+### 2. **Legal System Rights**  
+Non-native speakers in legal proceedings are entitled to interpreters under the **Court Interpreters Act of 1978**, which mandates interpreters for individuals who "speak only or primarily a language other than English" in federal courts. However, judges in lower courts often subjectively assess whether a defendant's English proficiency is sufficient to waive an interpreter, sometimes conflating conversational and legal English competency. This inconsistency risks undermining due process for limited-English-proficiency (LEP) individuals . Advocacy groups emphasize the need for clearer standards to ensure meaningful access to justice .
+
+---
+
+### 3. **Education Rights**  
+The **Equal Educational Opportunities Act (EEOA)** and landmark cases like *Lau v. Nichols* (1974) and *Castañeda v. Pickard* (1981) require schools to provide language assistance programs for LEP students. The Castañeda framework mandates that programs must:  
+- Be based on sound educational theory,  
+- Be implemented with adequate resources,  
+- Demonstrate effectiveness in overcoming language barriers .  
+Federal laws like the **Every Student Succeeds Act** (2015) further require schools to track and support English learners’ academic progress, though critics argue standardized testing often disadvantages non-native speakers .
+
+---
+
+### 4. **Voting Rights**  
+The **Voting Rights Act of 1965**, as amended in 1975, requires election materials in multiple languages for jurisdictions with significant non-English-speaking populations. This ensures LEP citizens can participate in elections. However, enforcement varies, and debates persist about expanding language access amid political polarization .
+
+---
+
+### 5. **Societal and Systemic Challenges**  
+Despite legal protections, non-native speakers often face implicit biases. For instance:  
+- **Employment**: Job postings requiring "native English" fluency (without justification) may unlawfully exclude qualified candidates .  
+- **Education**: Policies like the shift from bilingual education to English immersion under *No Child Left Behind* prioritized assimilation over multilingualism, disadvantaging some students .  
+- **Professional Settings**: Non-native speakers report microaggressions, such as mockery of accents or exclusionary use of idioms, which perpetuate systemic inequities .  
+
+---
+
+### Conclusion  
+While federal laws provide foundational protections against discrimination in employment, education, legal proceedings, and voting, gaps remain in enforcement and societal attitudes. Non-native speakers still navigate systemic barriers, such as subjective language assessments in courts or workplace biases. Advocacy for clearer standards and inclusive practices—such as prioritizing communication clarity over "native-like" fluency—is critical to advancing equity . For a deeper dive into specific cases or policies, consult the cited sources.


### PR DESCRIPTION
In the United States, the rights of non-native English speakers are protected in specific contexts under federal laws and policies, though challenges and ambiguities persist. Below is a synthesis of key legal and societal considerations:

### 1. **Employment Protections**  
Under **Title VII of the Civil Rights Act of 1964**, discrimination based on national origin—which includes language and accent—is prohibited. Employers cannot legally require a job applicant to be a "native speaker" unless they can prove that native-level fluency is essential for the role (e.g., editing, translation). Even then, the requirement must be narrowly tailored to actual job needs, not based on stereotypes about non-native speakers. For example, blanket English fluency requirements for roles where it is unnecessary (e.g., warehouse work) may violate anti-discrimination laws . Accent-based discrimination is only permissible if the accent "materially interferes" with job performance .

---

### 2. **Legal System Rights**  
Non-native speakers in legal proceedings are entitled to interpreters under the **Court Interpreters Act of 1978**, which mandates interpreters for individuals who "speak only or primarily a language other than English" in federal courts. However, judges in lower courts often subjectively assess whether a defendant's English proficiency is sufficient to waive an interpreter, sometimes conflating conversational and legal English competency. This inconsistency risks undermining due process for limited-English-proficiency (LEP) individuals . Advocacy groups emphasize the need for clearer standards to ensure meaningful access to justice .

---

### 3. **Education Rights**  
The **Equal Educational Opportunities Act (EEOA)** and landmark cases like *Lau v. Nichols* (1974) and *Castañeda v. Pickard* (1981) require schools to provide language assistance programs for LEP students. The Castañeda framework mandates that programs must:  
- Be based on sound educational theory,  
- Be implemented with adequate resources,  
- Demonstrate effectiveness in overcoming language barriers .  
Federal laws like the **Every Student Succeeds Act** (2015) further require schools to track and support English learners’ academic progress, though critics argue standardized testing often disadvantages non-native speakers .

---

### 4. **Voting Rights**  
The **Voting Rights Act of 1965**, as amended in 1975, requires election materials in multiple languages for jurisdictions with significant non-English-speaking populations. This ensures LEP citizens can participate in elections. However, enforcement varies, and debates persist about expanding language access amid political polarization .

---

### 5. **Societal and Systemic Challenges**  
Despite legal protections, non-native speakers often face implicit biases. For instance:  
- **Employment**: Job postings requiring "native English" fluency (without justification) may unlawfully exclude qualified candidates .  
- **Education**: Policies like the shift from bilingual education to English immersion under *No Child Left Behind* prioritized assimilation over multilingualism, disadvantaging some students .  
- **Professional Settings**: Non-native speakers report microaggressions, such as mockery of accents or exclusionary use of idioms, which perpetuate systemic inequities .  

---

### Conclusion  
While federal laws provide foundational protections against discrimination in employment, education, legal proceedings, and voting, gaps remain in enforcement and societal attitudes. Non-native speakers still navigate systemic barriers, such as subjective language assessments in courts or workplace biases. Advocacy for clearer standards and inclusive practices—such as prioritizing communication clarity over "native-like" fluency—is critical to advancing equity . For a deeper dive into specific cases or policies, consult the cited sources.